### PR TITLE
Fix: Send method should use plugin settings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ module.exports = {
     },
   },
 
-  init: (config) => {
+  init: (config, settings) => {
     let transporter = nodemailer.createTransport({
       host: config.host,
       port: config.port,
@@ -76,8 +76,8 @@ module.exports = {
         return new Promise((resolve, reject) => {
           // Default values.
           options = _.isObject(options) ? options : {};
-          options.from = options.from || config.username;
-          options.replyTo = options.replyTo || config.username;
+          options.from = options.from || settings.defaultFrom || config.username;
+          options.replyTo = options.replyTo || settings.defaultReplyTo || config.username;
           options.text = options.text || options.html;
           options.html = options.html || options.text;
 


### PR DESCRIPTION
Init method receives 2 arguments but only config is used in this plugin. It should use the second argument (`settings`) and use it when sending an email.

Fixes #5 