### PR TITLE
Updated plugins.js config file for V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,31 @@ npm i strapi-provider-email-smtp
 
 ## Configuration
 In your `config/plugins.js`, set the following:
-
+### Strapi v4:
+```javascript
+module.exports = ({ env }) => ({
+  email: {
+    config: {
+      provider: 'strapi-provider-email-smtp',
+      providerOptions: {
+        host: 'smtp.gmail.com', //SMTP Host
+        port: 465   , //SMTP Port
+        secure: true,
+        username: 'my.username@gmail.com',
+        password: 'my.password',
+        rejectUnauthorized: true,
+        requireTLS: true,
+        connectionTimeout: 1,
+      },
+    },
+    settings: {
+      from: 'my.username@gmail.com',
+      replyTo: 'my.username@gmail.com',
+    }, 
+  },    
+});
+```
+### Strapi v3:
 ```javascript
 module.exports = ({ env }) => ({
   email: {


### PR DESCRIPTION
Strapi V4 changed the way to configure plugins:
You have to wrap all the fields except from `settings` in `config`
You have to call the provider by the actual npm package name (strapi-provider-email-smtp instead of smtp).
Tho the docs are still incomplete (at the time of writing this), and I found the patch idea here: https://github.com/strapi/strapi/issues/11757
New plugin.js file tested and approved for V4.