### PR TITLE
Added option to disable authentication in Nodemailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module.exports = ({ env }) => ({
         rejectUnauthorized: true,
         requireTLS: true,
         connectionTimeout: 1,
+	useAuth: true,
       },
     },
     settings: {
@@ -48,6 +49,7 @@ module.exports = ({ env }) => ({
       rejectUnauthorized: true,
       requireTLS: true,
       connectionTimeout: 1,
+      useAuth: true,
     },
     settings: {
       from: 'my.username@gmail.com',

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,17 +53,29 @@ module.exports = {
       type: "enum",
       values: ["FALSE", "TRUE"],
     },
+    useAuth: {
+      label: "UseAuth",
+      type: "enum",
+      values: ["FALSE", "TRUE"],
+    },
   },
 
   init: (config, settings) => {
+    let auth = {};
+    let useAuth = toBool(config.useAuth);
+    if(useAuth) {
+      auth = {
+        user: config.username,
+        pass: config.password,
+      } 
+    } else {
+      auth = false;
+    }
     let transporter = nodemailer.createTransport({
       host: config.host,
       port: config.port,
       secure: toBool(config.secure),
-      auth: {
-        user: config.username,
-        pass: config.password,
-      },
+      auth: auth,
       tls: {
         rejectUnauthorized: toBool(config.rejectUnauthorized),
       },


### PR DESCRIPTION
Fixes issue #1 by adding an additional option `useAuth`, which allows to connect to the SMTP server without using authentication.